### PR TITLE
pod installを実行した際に表示される警告に対応

### DIFF
--- a/App/Memo.xcodeproj/project.pbxproj
+++ b/App/Memo.xcodeproj/project.pbxproj
@@ -734,7 +734,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = B07091FFFE1A49F255EEA8B5 /* Pods-Memo.debug.xcconfig */;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = "$(inherited)";
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
@@ -762,7 +762,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = EE0917E75F6037C03E76BC7C /* Pods-Memo.release.xcconfig */;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = "$(inherited)";
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
@@ -790,6 +790,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 371D377BEB43618752DECE08 /* Pods-MemoCore.debug.xcconfig */;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = "$(inherited)";
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
@@ -822,6 +823,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 9873ED0EC7A4CC439191EAE4 /* Pods-MemoCore.release.xcconfig */;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = "$(inherited)";
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;


### PR DESCRIPTION
# 関連するIssue

<!-- 
以下のように関連するIssueのリンクを貼る
- #1
-->

- なし

# 関連するPR

<!-- 
以下のように関連するPRのリンクを貼る
- #2
-->

- なし

# 作業した内容

<!-- 
以下のように作業した内容を書く
- [x] レイアウトを作成した
-->

- [x] pod installを実行した際に表示される警告に対応した
  - 以下の記事に従って対応した 
  - https://qiita.com/yosshi4486/items/d54e60d493d780b6e0cf 

```
[!] The `Memo [Debug]` target overrides the `ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES` build setting defined in `Pods/Target Support Files/Pods-Memo/Pods-Memo.debug.xcconfig'. This can lead to problems with the CocoaPods installation
    - Use the `$(inherited)` flag, or
    - Remove the build settings from the target.

[!] The `Memo [Release]` target overrides the `ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES` build setting defined in `Pods/Target Support Files/Pods-Memo/Pods-Memo.release.xcconfig'. This can lead to problems with the CocoaPods installation
    - Use the `$(inherited)` flag, or
    - Remove the build settings from the target.
```

# このPRでは作業しない残作業

<!-- 
以下のようにこのPRでは作業しない残作業を書く
- [ ] ロジックを実装する
-->

- なし

# 確認してほしい点

<!-- 
以下のようにこのPRでは作業しない残作業を書く
- [ ] 無事にビルドできるか
-->

- なし

# スクリーンショット

|作業前|作業後|
|-----------|---------|
|<img width=300 src="">|<img width=300 src="">|